### PR TITLE
Automatically parse JSON bodies on incoming requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,40 +7,40 @@ env:
   IMAGE_NAME: api_emulator
 
 jobs:
-#  test:
-#    runs-on: ubuntu-latest
-#    name: Build container
-#
-#    permissions:
-#      contents: read
-#
-#    steps:
-#    - name: Setup PHP
-#      uses: shivammathur/setup-php@v2
-#      with:
-#        php-version: 8.1
-#        tools: composer:v2
-#
-#    - name: Checkout
-#      uses: actions/checkout@v2
-#    - name: Get Composer Cache Directory
-#      id: composer-cache
-#      run: |
-#        echo "::set-output name=dir::$(composer config cache-files-dir)"
-#
-#    - uses: actions/cache@v2
-#      with:
-#        path: ${{ steps.composer-cache.outputs.dir }}
-#        key: ${{ runner.os }}-composer-default-${{ hashFiles('**/composer.lock') }}
-#        restore-keys: |
-#          ${{ runner.os }}-composer-default
-#
-#    - name: Install composer dependencies
-#      run: |
-#        composer install --no-interaction --no-progress
-#
-#    - name: Run unit tests
-#      run: vendor/bin/phpunit
+  test:
+    runs-on: ubuntu-latest
+    name: Build container
+
+    permissions:
+      contents: read
+
+    steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 8.1
+        tools: composer:v2
+
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: |
+        echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - uses: actions/cache@v2
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-default-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-default
+
+    - name: Install composer dependencies
+      run: |
+        composer install --no-interaction --no-progress
+
+    - name: Run unit tests
+      run: vendor/bin/phpunit
 
   build:
     runs-on: ubuntu-latest

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!-- Config file for PHPUnit automated tests -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage/>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>test/unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/JSONRequestBodyParser.php
+++ b/src/JSONRequestBodyParser.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Ingenerator\ApiEmulator;
+
+use Ingenerator\PHPUtils\StringEncoding\JSON;
+use Psr\Http\Message\ServerRequestInterface;
+use function strtok;
+
+class JSONRequestBodyParser
+{
+
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
+    {
+        if ($this->hasJsonContent($request)) {
+            if ($request->getParsedBody() !== null) {
+                throw new \UnexpectedValueException(
+                    'Can\'t automatically parse request with application/json content-type as it already has a parsed body'
+                );
+            }
+            
+            $json = $this->readJsonBodyContent($request);
+
+            return $request->withParsedBody(JSON::decode($json));
+        }
+
+        return $request;
+    }
+
+    private function hasJsonContent(ServerRequestInterface $request): bool
+    {
+        $content_type = $request->getHeaderLine('Content-Type');
+        // ignore charset etc
+        $media = strtok($content_type, ';');
+
+        return $media === 'application/json';
+    }
+
+    private function readJsonBodyContent(ServerRequestInterface $request): string
+    {
+        // Reading the body leaves the pointer at the end so we have to explicitly rewind after we've
+        // read it to avoid mutating state.
+        try {
+            return $request->getBody()->getContents();
+        } finally {
+            $request->getBody()->rewind();
+        }
+
+    }
+}

--- a/src/RequestExecutor.php
+++ b/src/RequestExecutor.php
@@ -12,14 +12,19 @@ class RequestExecutor
 {
     public function __construct(
         private LoggerInterface $logger,
-        private HandlerLoader $handler_loader = new HandlerLoader
+        private HandlerLoader $handler_loader = new HandlerLoader,
+        private JSONRequestBodyParser $json_body_parser = new JSONRequestBodyParser,
     ) {
     }
 
     public function execute(ServerRequestInterface $request): ResponseInterface
     {
         $handler = $this->handler_loader->getHandler($request);
-        $response = $handler->handle($request);
+
+        $response = $handler->handle(
+            // Guzzle doesn't natively decode JSON bodies
+            $this->json_body_parser->parse($request)
+        );
 
         $this->logRequest($request, $handler, $response);
 

--- a/test/unit/JSONBodyRequestParserTest.php
+++ b/test/unit/JSONBodyRequestParserTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace test\unit;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Ingenerator\ApiEmulator\JSONRequestBodyParser;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class JSONBodyRequestParserTest extends TestCase
+{
+
+    /**
+     * @testWith [[], "no content type header"]
+     *           [{"Content-Type": "application/x-www-form-urlencoded"}]
+     */
+    public function test_it_returns_same_request_if_not_json($headers)
+    {
+        $request = new ServerRequest(
+            'GET',
+            '/any/uri',
+            $headers,
+            '{"it looks like":"json but it is not"}'
+        );
+
+        $this->assertSame($request, $this->newSubject()->parse($request));
+    }
+
+    /**
+     * @testWith ["application/json"]
+     *           ["application/json; charset=utf8"]
+     *           ["application/json;charset=utf8"]
+     */
+    public function test_it_returns_request_with_decoded_json_body(string $content_type)
+    {
+        $request = new ServerRequest(
+            'GET',
+            '/any/uri',
+            ['Content-Type' => $content_type],
+            '{"I am": "a json body"}',
+        );
+
+        $new_request = $this->newSubject()->parse($request);
+        $this->assertNotSame($request, $new_request, 'Should have returned a new request');
+        $this->assertSame(['I am' => 'a json body'], $new_request->getParsedBody());
+    }
+
+    public function test_the_raw_content_is_still_readable_after_parsing()
+    {
+        $original_body = '["any", "json", "here"]';
+        $parsed = $this->newSubject()->parse(
+            new ServerRequest(
+                'GET',
+                '/any/uri',
+                ['Content-Type' => 'application/json'],
+                $original_body,
+            )
+        );
+
+        $this->assertSame(['any', 'json', 'here'], $parsed->getParsedBody());
+        $this->assertSame($original_body, $parsed->getBody()->getContents());
+    }
+
+    public function test_it_throws_if_json_request_already_has_parsed_body()
+    {
+        // Shouldn't be possible at the PHP layer, but just in case guzzle behaviour changes in future
+        $request = (new ServerRequest(
+            'GET',
+            '/any/uri',
+            ['Content-Type' => 'application/json'],
+            '["collision"]',
+        ))->withParsedBody(['post' => 'stuff']);
+        $subject = $this->newSubject();
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('parsed body');
+        $subject->parse($request);
+    }
+
+    private function newSubject(): JSONRequestBodyParser
+    {
+        return new JSONRequestBodyParser();
+    }
+}


### PR DESCRIPTION
Guzzle doesn't do this by default due to the risk of large payloads needing sanity checks before attempting to parse, in our case it's safe enough to do it.