### PR TITLE
Support both `/ping-200` & `/ping-200/{any child path}` for simple cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+* Support both `/ping-200` and `/ping-200/{any child path}` for simple cases that just need a 200

--- a/default_handlers/handlers.php
+++ b/default_handlers/handlers.php
@@ -7,7 +7,7 @@ return [
     // Do not use for healthchecking the emulator as that will pollute the captured app requests
     // and make your assertions harder. Instead for that you can use GET /_emulator-meta/health
     // which is not recorded with the application requests.
-    '#^\w+ /ping-200$#' => fn () => new Response(
+    '#^\w+ /ping-200(/|$)#' => fn () => new Response(
         200,
         ['Content-Type' => 'text/plain'],
         'OK'


### PR DESCRIPTION
The existing `/ping-200` endpoint is good for anything that needs a simple 200 response, but often we want to configure more than one in a project and it can get confusing which of the services pointing at `/ping-200` were called.

So add matching for *anything* under `/ping-200` to allow us to namespace requests without having to add custom handlers at all.