### PR TITLE
Use SIGINT to stop this container gracefully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ ENV INGENERATOR_ENV=standalone
 ENV HANDLERS_FILE=/api_emulator/default_handlers/handlers.php
 ENV PORT=80
 
+STOPSIGNAL SIGINT
+
 ENTRYPOINT ["/api_emulator/entrypoint.sh"]


### PR DESCRIPTION
Default docker stopsignal of SIGTERM does not stop php -S

So inevitably this container is running until whatever timeout eventually uses SIGKILL to stop it.